### PR TITLE
off by one when reporting line reading error

### DIFF
--- a/src/main.rs
+++ b/src/main.rs
@@ -25,7 +25,7 @@ fn test_index() {
 
     for (i, line) in reader.lines().enumerate() {
         let line: String = line
-            .unwrap_or_else(|_| panic!("Error while reading file: `{}` at line: {}", filename, i));
+            .unwrap_or_else(|_| panic!("Error while reading file: `{}` at line: {}", filename, i+1));
 
         let split = line.split(|c: char| !c.is_alphanumeric());
 


### PR DESCRIPTION
see https://github.com/glmark2/glmark2/issues/109 on how to cause such an error

that EOL at EOF was added by github editing, I didn't intend to.